### PR TITLE
Refactor getComponentName function

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -23,6 +23,12 @@ describe('utils', () => {
     it('gets component name', () => {
       expect(getComponentName()).toEqual('_callCircusTest')
     })
+
+    it('returns empty string if error.stack is not supported', () => {
+      const customError = new Error('error without stack')
+      delete customError.stack
+      expect(getComponentName(customError)).toEqual('')
+    })
   })
 
   describe('getPrinter', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -24,9 +24,16 @@ describe('utils', () => {
       expect(getComponentName()).toEqual('_callCircusTest')
     })
 
-    it('returns empty string if error.stack is not supported', () => {
+    it('returns empty string if error.stack is not supported by the browser', () => {
       const customError = new Error('error without stack')
       delete customError.stack
+      expect(getComponentName(customError)).toEqual('')
+    })
+
+    it('returns empty string if error.stack has different format', () => {
+      const customError = new Error('error with unsupported stack')
+      customError.stack =
+        'This is custom implementation of stack: calledThis > calledThat'
       expect(getComponentName(customError)).toEqual('')
     })
   })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,9 +78,9 @@ export function getComponentName(
 
   re.exec(error.stack)
   re.exec(error.stack)
-  const m = re.exec(error.stack) ?? []
+  const m = re.exec(error.stack)
 
-  return String(m[1] || m[2])
+  return m ? String(m[1] || m[2]) : ''
 }
 
 export function getRenderFunctionProps<T>(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,25 +65,22 @@ export function getGroupLabel(
   return `${typeWrapper}${componentNameWrapper}${timeWrapper}`
 }
 
-export function getComponentName(): string {
-  // Tested in the scope of useLog testing
-  try {
-    throw new Error('Getting the stack of error to parse it for component name')
-  } catch (error) {
-    /* istanbul ignore next */
-    if (error instanceof Error && error?.stack) {
-      const re = /(\w+)@|at (\w+) \(/g
-
-      re.exec(error.stack ?? '')
-      re.exec(error.stack ?? '')
-      const m = re.exec(error.stack ?? '') ?? []
-
-      return String(m[1] || m[2])
-    }
-
-    /* istanbul ignore next */
-    return '' // will be never reached since getComponentName always throws an instance of Error to parse the stack
+export function getComponentName(
+  error = new Error(
+    'Getting the stack of error to parse it for component name',
+  ),
+): string {
+  if (!error.stack) {
+    return ''
   }
+
+  const re = /(\w+)@|at (\w+) \(/g
+
+  re.exec(error.stack)
+  re.exec(error.stack)
+  const m = re.exec(error.stack) ?? []
+
+  return String(m[1] || m[2])
 }
 
 export function getRenderFunctionProps<T>(


### PR DESCRIPTION
## Why?
I noticed this code:
```
try {
  throw new Error('...')
} catch (error) {
  ...
}
```

I think there is no need to throw Error object just to get error stack, it's enough to create Error object and use it, like so:
```
const error = new Error('...')
```

Additionally, [Error.prototype.stack is non-standard](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) and there might be a situation where error.stack is `undefined`, so I added test for this case (previously it was ignored from coverage). In order to do that, I had to move error as optional first argument to this function. There might be other ways to do it, but this was the easiest one (couldn't correctly override global Error constructor)